### PR TITLE
feat(ci): enhance Claude workflow permissions and allowed tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write      # For creating branches and commits
+      pull-requests: write # For creating PRs and comments
+      issues: write        # For updating issues
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read       # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,7 +50,21 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          allowed_tools: |
+            Bash(npm install)
+            Bash(npm run build)
+            Bash(npm run test:*)
+            Bash(npm run lint:*)
+            Bash(bun install)
+            Bash(bun run build)
+            Bash(bun test)
+            Bash(bun run coverage)
+            Bash(git checkout -b *)
+            Bash(git add *)
+            Bash(git commit -m *)
+            Edit
+            MultiEdit
+            Write
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |


### PR DESCRIPTION
## Summary
- Upgrade Claude workflow permissions to enable write access for contents, pull-requests, and issues
- Add support for bun package manager alongside npm for Claude's allowed tools
- Include git operations and code editing tools in allowed_tools configuration

## Changes
- Changed permissions from read-only to write for contents, pull-requests, and issues
- Added bun commands (install, build, test, coverage) to allowed_tools
- Added git operations (checkout, add, commit) to allowed_tools
- Added Edit, MultiEdit, and Write tools for code modifications
- Restructured allowed_tools to multi-line format for better readability

## Test plan
- [ ] Verify Claude can create branches when invoked
- [ ] Verify Claude can make commits and create PRs
- [ ] Verify Claude can run both npm and bun commands
- [ ] Verify Claude can edit files using the allowed tools

🤖 Generated with [Claude Code](https://claude.ai/code)