### PR TITLE
fix: remove path filters from CI workflow to run on all changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,8 @@ name: CI
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '.gitignore'
-      - 'LICENSE'
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '.gitignore'
-      - 'LICENSE'
 
 env:
   BUN_VERSION: latest


### PR DESCRIPTION
Remove paths-ignore filters so CI runs on documentation changes and all other files. This ensures PRs with only documentation changes can satisfy branch protection rules.

🤖 Generated with [Claude Code](https://claude.ai/code)