### PR TITLE
fix: resolve document rendering issue in print view

### DIFF
--- a/packages/viewer/src/components/page-render-utils.tsx
+++ b/packages/viewer/src/components/page-render-utils.tsx
@@ -37,6 +37,31 @@ export function renderPrintPages(options: PageRenderOptions): React.ReactElement
     tempDiv.innerHTML = htmlContent;
     const pageElements = tempDiv.querySelectorAll(".page");
 
+    // If no page elements found, treat the entire content as a single page
+    if (pageElements.length === 0) {
+      const singlePage = (
+        <article
+          key={0}
+          className="print-page"
+          data-testid="parsed-document-page-1"
+          data-page-number={1}
+          data-page-type="parsed-document"
+          data-content-type="dom-rendered"
+          data-total-pages={1}
+          id="page-1"
+          aria-label="Page 1 of 1"
+          role="document"
+          dangerouslySetInnerHTML={{ __html: htmlContent }}
+        />
+      );
+      
+      if (totalPages !== 1) {
+        setTimeout(() => setTotalPages(1), 0);
+      }
+      
+      return [singlePage];
+    }
+
     // Update total pages when pages change
     if (pageElements.length !== totalPages) {
       setTimeout(() => setTotalPages(pageElements.length), 0);


### PR DESCRIPTION
## Summary
- Fix page tracking errors by handling cases where DOM renderer doesn't produce .page elements
- Add fallback to treat entire content as single page when no page elements found
- Remove debug console.log statements

## Problem
Documents were not rendering in the print view due to the DOM renderer not producing pages with  elements. The rendering logic was looking for these elements and returning an empty array when they weren't found.

## Solution
Added a fallback in  to treat the entire content as a single page when no  elements are found. This ensures documents always render properly in both Read and Print modes.

## Test Plan
- [x] Manually tested with multiple documents (001.docx, 011.docx)
- [x] Verified no console errors
- [x] Confirmed page tracking works correctly
- [ ] Need to add automated tests for this case

Fixes the infinite "No .print-page elements found for page tracking" console errors.