### PR TITLE
fix: only check linting errors in CI, not formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
           packages/*/build
         retention-days: 1
 
-  # Run linting and formatting checks in parallel
+  # Run linting checks in parallel (formatting is not enforced)
   lint:
-    name: Lint & Format
+    name: Lint
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -82,8 +82,8 @@ jobs:
     - name: Install dependencies
       run: bun install --frozen-lockfile
       
-    - name: Run Biome lint
-      run: bun run lint
+    - name: Run Biome lint (check only)
+      run: biome lint . --diagnostic-level=error
       
     - name: Check file sizes
       run: bun run check-file-sizes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       run: bun install --frozen-lockfile
       
     - name: Run Biome lint (check only)
-      run: biome lint . --diagnostic-level=error
+      run: bunx biome lint . --diagnostic-level=error
       
     - name: Check file sizes
       run: bun run check-file-sizes


### PR DESCRIPTION
## Summary
- Changed lint job to only check linting errors with `biome lint . --diagnostic-level=error`
- Formatting errors no longer block CI status
- Updated job name from "Lint & Format" to just "Lint"

## Test plan
- [ ] CI workflow runs successfully
- [ ] Only linting errors block CI, not formatting issues
- [ ] File size checks continue to work

This change ensures that formatting inconsistencies don't fail CI builds while still enforcing important linting rules.

🤖 Generated with [Claude Code](https://claude.ai/code)