### PR TITLE
fix: e2e tests now only depend on build, not unit/typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,11 +164,11 @@ jobs:
     - name: Run unit tests with coverage
       run: bun run test:coverage
 
-  # Run E2E tests only after all other checks pass
+  # Run E2E tests after build completes
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [build, typecheck, unit-tests]  # Lint runs in parallel, not a blocker
+    needs: [build]  # Only depends on build artifacts
     strategy:
       matrix:
         # Run tests in parallel shards


### PR DESCRIPTION
## Summary
- E2E tests now only depend on build artifacts, not unit tests or typecheck
- This allows e2e, unit tests, typecheck, and lint to all run in parallel after build completes
- Maximizes CI parallelization for faster overall execution time

## Test plan
- [ ] CI workflow runs successfully
- [ ] E2E tests start as soon as build completes
- [ ] Unit tests, typecheck, lint, and e2e all run in parallel

This change improves CI efficiency by allowing maximum parallelization of independent test jobs.

🤖 Generated with [Claude Code](https://claude.ai/code)