### PR TITLE
refactor: remove line spacing validation for faithful document rendering

### DIFF
--- a/packages/dom-renderer/src/units.ts
+++ b/packages/dom-renderer/src/units.ts
@@ -33,6 +33,9 @@ export function halfPointsToPt(halfPoints: string | number): string {
   return `${halfPointsToPoints(value)}pt`;
 }
 
+// Standard line spacing value in twips (normal = 240 twips = 1.0x)
+const NORMAL_LINE_SPACING_TWIPS = 240;
+
 /**
  * Convert line spacing based on line rule
  * @param value - The line spacing value in twips
@@ -51,17 +54,7 @@ export function convertLineSpacing(value: number, lineRule?: "auto" | "exact" | 
     default:
       // Auto means the value is in 240ths of a line (relative to font size)
       // Normal line spacing is 240 twips, so divide by 240 to get a unitless multiplier
-      const ratio = value / 240;
-      
-      // Ensure reasonable bounds for auto line spacing
-      const minRatio = 0.8; // Don't go below 80% (too cramped)
-      const maxRatio = 3.0; // Don't go above 300% (too spaced)
-      const clampedRatio = Math.max(minRatio, Math.min(maxRatio, ratio));
-      
-      if (clampedRatio !== ratio) {
-        console.warn(`Line spacing ratio ${ratio.toFixed(2)} is extreme, clamping to ${clampedRatio.toFixed(2)}`);
-      }
-      
-      return clampedRatio.toFixed(2);
+      const ratio = value / NORMAL_LINE_SPACING_TWIPS;
+      return ratio.toFixed(2);
   }
 }


### PR DESCRIPTION
## Summary
- Remove extreme value validation and capping logic - documents should render exactly as specified  
- Extract NORMAL_LINE_SPACING_TWIPS constant to units.ts for consistency
- Remove bounds checking in convertLineSpacing() auto mode 
- Create shared applyLineSpacing() helper to eliminate code duplication
- Update tests to verify faithful rendering of actual document values (951 twips = 47.55pt)

## Key Changes
1. **Remove validation logic**: No more capping "extreme" line spacing values - if a document specifies 951 twips (47.55pt), that's what gets rendered
2. **Fix code consistency**: 
   - Consistent behavior between convertLineSpacing() and style functions
   - Single source of truth for line spacing conversion  
   - Removed inconsistent warning messages
3. **Extract magic numbers**: Added NORMAL_LINE_SPACING_TWIPS constant
4. **Eliminate duplication**: Shared applyLineSpacing() helper for both paragraphs and headings

## Context
Analysis of 005.docx revealed that the "extreme" 951 twips line spacing value is actually in the document and should be rendered faithfully as 47.55pt. The validation logic was preventing correct document rendering.

## Test plan
- [x] All existing tests pass
- [x] Line spacing tests updated to verify faithful rendering  
- [x] Removed validation-related test expectations
- [x] Verified 005.docx paragraph with "D" renders correctly with 47.55pt line spacing

🤖 Generated with [Claude Code](https://claude.ai/code)