### PR TITLE
fix: ensure Claude Code review waits for CI to pass

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,13 +11,62 @@ on:
     #   - "src/**/*.jsx"
 
 jobs:
+  wait-for-ci:
+    runs-on: ubuntu-latest
+    outputs:
+      should-continue: ${{ steps.wait.outputs.should-continue }}
+    steps:
+      - name: Wait for CI to complete
+        id: wait
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Wait up to 10 minutes for CI to complete
+            const maxAttempts = 20; // 20 * 30s = 10 minutes
+            let attempts = 0;
+            
+            while (attempts < maxAttempts) {
+              attempts++;
+              
+              // Get check runs for this commit
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.payload.pull_request.head.sha,
+              });
+              
+              // Find the CI Status check
+              const ciCheck = checkRuns.check_runs.find(run => 
+                run.name === 'CI Status' || run.name === 'all-checks-passed'
+              );
+              
+              if (ciCheck) {
+                console.log(`CI check status: ${ciCheck.status}, conclusion: ${ciCheck.conclusion}`);
+                
+                if (ciCheck.status === 'completed') {
+                  // CI has completed, check if it passed
+                  if (ciCheck.conclusion === 'success') {
+                    console.log('CI passed! Proceeding with Claude review.');
+                    core.setOutput('should-continue', 'true');
+                    return;
+                  } else {
+                    console.log('CI failed. Skipping Claude review.');
+                    core.setOutput('should-continue', 'false');
+                    return;
+                  }
+                }
+              }
+              
+              console.log(`Attempt ${attempts}/${maxAttempts}: CI not complete yet, waiting 30s...`);
+              await new Promise(resolve => setTimeout(resolve, 30000)); // Wait 30s
+            }
+            
+            console.log('Timeout waiting for CI. Skipping Claude review.');
+            core.setOutput('should-continue', 'false');
+
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    needs: wait-for-ci
+    if: needs.wait-for-ci.outputs.should-continue == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write      # For checking out code and potential fixes
@@ -85,4 +134,3 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-


### PR DESCRIPTION
## Summary
- Added `wait-for-ci` job that polls GitHub API for CI status before running Claude review
- Waits up to 10 minutes for CI checks to complete
- Only runs Claude review if CI passes (`conclusion == 'success'`)
- Skips review if CI fails or times out

## Problem
The previous approach using `workflow_run` trigger didn't work properly - Claude Code review never ran on PR #37 even after CI passed. This was due to complexities with PR context in workflow_run events.

## Solution
This PR uses a simpler approach:
1. Keeps the original `pull_request` trigger for proper PR context
2. Adds a `wait-for-ci` job that polls the GitHub API for CI status
3. Only proceeds to Claude review if CI passes
4. Times out after 10 minutes to avoid hanging

## Benefits
- Saves Claude API usage by not reviewing code with failing tests
- Maintains proper PR context for Claude review
- More reliable than workflow_run trigger
- Clear logging of CI status while waiting

🤖 Generated with [Claude Code](https://claude.ai/code)