### PR TITLE
refactor: replace (cell as any) with proper ProcessingTableCell interface

### DIFF
--- a/packages/document-types/src/index.ts
+++ b/packages/document-types/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./document";
+export * from "./processing-types";

--- a/packages/document-types/src/processing-types.ts
+++ b/packages/document-types/src/processing-types.ts
@@ -1,0 +1,18 @@
+/**
+ * Processing types for internal document manipulation
+ * These interfaces extend the base types with temporary properties
+ * used during parsing and rendering operations
+ */
+
+import type { TableCell } from "./index";
+
+/**
+ * Internal interface for table cells during processing
+ * Extends TableCell with temporary properties used during vMerge calculation
+ */
+export interface ProcessingTableCell extends TableCell {
+  /** Temporary property to track vMerge state during parsing */
+  _vMerge?: "restart" | "continue";
+  /** Temporary property to mark cells that should be hidden due to merging */
+  _merged?: boolean;
+}

--- a/packages/dom-renderer/src/enhanced-table-utils.ts
+++ b/packages/dom-renderer/src/enhanced-table-utils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Table, TableCell, TableBorder, TableShading } from "@browser-document-viewer/parser";
+import type { ProcessingTableCell } from "@browser-document-viewer/document-types";
 import type { ST_Border, ST_Shd } from "@browser-document-viewer/ooxml-types";
 import { validateColor, validateCSSValue, validateNumeric, validateBorderStyle } from "./css-validation";
 
@@ -239,7 +240,7 @@ export function renderEnhancedTable(table: Table): string {
 
     for (const cell of row.cells) {
       // Skip cells marked as merged
-      if ((cell as any)._merged) continue;
+      if ((cell as ProcessingTableCell)._merged) continue;
       html += renderEnhancedTableCell(cell, rowIndex === 0);
     }
 

--- a/packages/dom-renderer/src/table-utils.ts
+++ b/packages/dom-renderer/src/table-utils.ts
@@ -1,4 +1,5 @@
 import type { Table } from "@browser-document-viewer/parser";
+import type { ProcessingTableCell } from "@browser-document-viewer/document-types";
 import { renderEnhancedTable as renderEnhancedTableWithVisualFidelity } from "./enhanced-table-utils";
 
 /**
@@ -63,7 +64,7 @@ export function renderEnhancedTable(
       const cellKey = `${rowIndex}-${cellIndex}`;
 
       // Skip if this cell is part of a merged cell or marked as merged
-      if (mergedCells.has(cellKey) || (cell as any)._merged) return;
+      if (mergedCells.has(cellKey) || (cell as ProcessingTableCell)._merged) return;
 
       const isHeader = rowIndex === 0;
       const cellEl = doc.createElement(isHeader ? "th" : "td");

--- a/packages/markdown-renderer/src/index.ts
+++ b/packages/markdown-renderer/src/index.ts
@@ -40,8 +40,8 @@ function safeBase64Encode(data: ArrayBuffer): string {
 
 function renderTextRun(run: TextRun): string {
   // Check if this is a footnote reference
-  if ((run as any)._footnoteRef) {
-    return `[^${(run as any)._footnoteRef}]`;
+  if (run._footnoteRef) {
+    return `[^${run._footnoteRef}]`;
   }
 
   let text = run.text;

--- a/packages/parser/src/parsers/docx/enhanced-table-parser.test.ts
+++ b/packages/parser/src/parsers/docx/enhanced-table-parser.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from "bun:test";
 import { parseEnhancedTable, parseEnhancedTableBorder, calculateRowSpans, parseEnhancedTableCell } from "./enhanced-table-parser";
 import type { Table, TableBorder, TableShading } from "../../types/document";
+import type { ProcessingTableCell } from "@browser-document-viewer/document-types";
 import { ST_Border, ST_Shd } from "@browser-document-viewer/ooxml-types";
 import { JSDOM } from "jsdom";
 
@@ -223,8 +224,8 @@ describe("Enhanced Table Parser with OOXML Types", () => {
       expect(table?.rows[0].cells[1].rowspan).toBe(3);
       
       // Check that cells at 1,1 and 2,1 are marked as merged
-      expect((table?.rows[1].cells[1] as any)._merged).toBe(true);
-      expect((table?.rows[2].cells[1] as any)._merged).toBe(true);
+      expect((table?.rows[1].cells[1] as ProcessingTableCell)._merged).toBe(true);
+      expect((table?.rows[2].cells[1] as ProcessingTableCell)._merged).toBe(true);
       
       // Restore mocks
       jest.restoreAllMocks();
@@ -358,7 +359,7 @@ describe("Enhanced Table Parser with OOXML Types", () => {
       expect(table?.rows[0].cells[0].rowspan).toBe(2);
       
       // Cell in second row should be marked as merged
-      expect((table?.rows[1].cells[0] as any)._merged).toBe(true);
+      expect((table?.rows[1].cells[0] as ProcessingTableCell)._merged).toBe(true);
       
       // Other cells should not have rowspan
       expect(table?.rows[0].cells[1].rowspan).toBeUndefined();

--- a/packages/parser/src/parsers/docx/enhanced-table-parser.ts
+++ b/packages/parser/src/parsers/docx/enhanced-table-parser.ts
@@ -12,6 +12,7 @@ import type {
   TableCellBorders,
   TableBorder,
 } from "../../types/document";
+import type { ProcessingTableCell } from "@browser-document-viewer/document-types";
 import type {
   CT_TblPr,
   CT_TblBorders,
@@ -50,8 +51,8 @@ export function calculateRowSpans(table: Table): void {
       const row = table.rows[rowIndex];
       if (!row || !row.cells[colIndex]) continue;
       
-      const cell = row.cells[colIndex];
-      const vMerge = (cell as any)._vMerge;
+      const cell = row.cells[colIndex] as ProcessingTableCell;
+      const vMerge = cell._vMerge;
       
       if (vMerge === "restart") {
         // Start of a new merged region
@@ -63,7 +64,7 @@ export function calculateRowSpans(table: Table): void {
         // Mark this cell as merged (it should not be rendered)
         mergedCells.add(`${rowIndex}-${colIndex}`);
         // Hide this cell by marking it
-        (cell as any)._merged = true;
+        (cell as ProcessingTableCell)._merged = true;
       } else if (rowspanStart !== -1) {
         // End of merged region (cell without vMerge after a merge)
         if (rowspanCount > 1) {
@@ -90,7 +91,8 @@ export function calculateRowSpans(table: Table): void {
   // Clean up temporary vMerge properties but keep _merged for rendering
   for (const row of table.rows) {
     for (const cell of row.cells) {
-      delete (cell as any)._vMerge;
+      const processingCell = cell as ProcessingTableCell;
+      delete processingCell._vMerge;
     }
   }
 }
@@ -275,7 +277,7 @@ export function parseEnhancedTableCell(
     if (vMergeElement) {
       const vMergeVal = vMergeElement.getAttribute("w:val") as ST_Merge | null;
       // Mark the cell with vMerge info for post-processing
-      (cell as any)._vMerge = vMergeVal || "continue"; // If no val attribute, it's implicitly "continue"
+      (cell as ProcessingTableCell)._vMerge = vMergeVal || "continue"; // If no val attribute, it's implicitly "continue"
     }
 
     // Vertical alignment


### PR DESCRIPTION
## Summary
- ✅ Created `ProcessingTableCell` interface extending `TableCell` with temporary properties
- ✅ Replaced all `(cell as any)` type assertions with proper types
- ✅ Removed unnecessary type assertion for `_footnoteRef` in TextRun
- ✅ Improved type safety throughout table processing code

## Changes

### New Interface
Created `ProcessingTableCell` interface in the `document-types` package:
```typescript
export interface ProcessingTableCell extends TableCell {
  /** Temporary property to track vMerge state during parsing */
  _vMerge?: "restart" | "continue";
  /** Temporary property to mark cells that should be hidden due to merging */
  _merged?: boolean;
}
```

### Type Safety Improvements
- Replaced 5 instances of `(cell as any)` with `ProcessingTableCell` type
- Removed unnecessary type assertion for `run._footnoteRef` (already in TextRun interface)
- All changes maintain backward compatibility

## Benefits
- Better IDE support with proper type hints
- Compile-time type checking for temporary properties
- Clear documentation of internal processing state
- Easier to maintain and refactor

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>