### PR TITLE
feat: add run-level border support for DOCX parsing

### DIFF
--- a/packages/parser/src/parsers/docx/run-border.test.ts
+++ b/packages/parser/src/parsers/docx/run-border.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "bun:test";
+import "../../test-setup";
+import { parseRun } from "./run-parser";
+import { ST_Border } from "@browser-document-viewer/ooxml-types";
+
+describe("Run border parsing", () => {
+  it("should parse run with text border", () => {
+    const parser = new DOMParser();
+    const xmlString = `
+      <w:r xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:rPr>
+          <w:bdr w:val="single" w:sz="4" w:space="0" w:color="auto"/>
+        </w:rPr>
+        <w:t>box</w:t>
+      </w:r>
+    `;
+    const doc = parser.parseFromString(xmlString, "text/xml");
+    const runElement = doc.documentElement;
+    const run = parseRun(runElement, "http://schemas.openxmlformats.org/wordprocessingml/2006/main");
+    
+    expect(run).not.toBeNull();
+    expect(run?.border).toBeDefined();
+    expect(run?.border?.style).toBe(ST_Border.Single);
+    expect(run?.border?.size).toBe(4);
+    expect(run?.border?.space).toBe(0);
+    expect(run?.border?.color).toBeUndefined(); // auto color is not stored
+    expect(run?.text).toBe("box");
+  });
+
+  it("should parse run with colored border", () => {
+    const parser = new DOMParser();
+    const xmlString = `
+      <w:r xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:rPr>
+          <w:bdr w:val="double" w:sz="8" w:space="2" w:color="FF0000"/>
+        </w:rPr>
+        <w:t>bordered text</w:t>
+      </w:r>
+    `;
+    const doc = parser.parseFromString(xmlString, "text/xml");
+    const runElement = doc.documentElement;
+    const run = parseRun(runElement, "http://schemas.openxmlformats.org/wordprocessingml/2006/main");
+    
+    expect(run).not.toBeNull();
+    expect(run?.border).toBeDefined();
+    expect(run?.border?.style).toBe(ST_Border.Double);
+    expect(run?.border?.size).toBe(8);
+    expect(run?.border?.space).toBe(2);
+    expect(run?.border?.color).toBe("#FF0000");
+    expect(run?.text).toBe("bordered text");
+  });
+
+  it("should handle run without border", () => {
+    const parser = new DOMParser();
+    const xmlString = `
+      <w:r xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:rPr>
+          <w:b/>
+        </w:rPr>
+        <w:t>normal text</w:t>
+      </w:r>
+    `;
+    const doc = parser.parseFromString(xmlString, "text/xml");
+    const runElement = doc.documentElement;
+    const run = parseRun(runElement, "http://schemas.openxmlformats.org/wordprocessingml/2006/main");
+    
+    expect(run).not.toBeNull();
+    expect(run?.border).toBeUndefined();
+    expect(run?.bold).toBe(true);
+    expect(run?.text).toBe("normal text");
+  });
+
+  it("should parse run with border and other formatting", () => {
+    const parser = new DOMParser();
+    const xmlString = `
+      <w:r xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:rPr>
+          <w:b/>
+          <w:i/>
+          <w:bdr w:val="dotted" w:sz="6" w:color="0000FF"/>
+          <w:color w:val="FFFFFF"/>
+          <w:sz w:val="24"/>
+        </w:rPr>
+        <w:t>formatted with border</w:t>
+      </w:r>
+    `;
+    const doc = parser.parseFromString(xmlString, "text/xml");
+    const runElement = doc.documentElement;
+    const run = parseRun(runElement, "http://schemas.openxmlformats.org/wordprocessingml/2006/main");
+    
+    expect(run).not.toBeNull();
+    expect(run?.border).toBeDefined();
+    expect(run?.border?.style).toBe(ST_Border.Dotted);
+    expect(run?.border?.size).toBe(6);
+    expect(run?.border?.color).toBe("#0000FF");
+    expect(run?.bold).toBe(true);
+    expect(run?.italic).toBe(true);
+    expect(run?.color).toBe("FFFFFF");
+    expect(run?.fontSize).toBe("24");
+    expect(run?.text).toBe("formatted with border");
+  });
+});

--- a/packages/parser/src/parsers/docx/style-parser.ts
+++ b/packages/parser/src/parsers/docx/style-parser.ts
@@ -79,6 +79,7 @@ export interface DocxRunProperties {
   lang?: string;
   bidi?: boolean; // Bidirectional text (w:bidi attribute on w:lang)
   rtl?: boolean; // Right-to-left text direction (w:rtl)
+  border?: DocxBorder; // Text border (w:bdr)
 }
 
 export interface DocxStylesheet {

--- a/packages/parser/src/parsers/docx/theme-parser.test.ts
+++ b/packages/parser/src/parsers/docx/theme-parser.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "bun:test";
+import "../../test-setup";
+import { resolveThemeFontAttribute, resolveThemeColor, resolveThemeFont } from "./theme-parser";
+import type { DocxTheme } from "./theme-parser";
+
+describe("Theme Font Attribute Resolution", () => {
+  const mockTheme: DocxTheme = {
+    colors: new Map([
+      ["dk1", "#000000"],
+      ["lt1", "#FFFFFF"],
+      ["accent1", "#4F81BD"],
+      ["text1", "#000000"],
+      ["background1", "#FFFFFF"]
+    ]),
+    fonts: {
+      major: new Map([
+        ["latin", "Ubuntu"],
+        ["ea", "SimHei"],
+        ["cs", "Arial Unicode MS"]
+      ]),
+      minor: new Map([
+        ["latin", "Ubuntu"],
+        ["ea", "SimSun"],
+        ["cs", "Arial Unicode MS"]
+      ])
+    }
+  };
+
+  it("should resolve minor font theme attributes", () => {
+    expect(resolveThemeFontAttribute("minorHAnsi", mockTheme)).toBe("Ubuntu");
+    expect(resolveThemeFontAttribute("minorAscii", mockTheme)).toBe("Ubuntu");
+    expect(resolveThemeFontAttribute("minorEastAsia", mockTheme)).toBe("SimSun");
+    expect(resolveThemeFontAttribute("minorBidi", mockTheme)).toBe("Arial Unicode MS");
+  });
+
+  it("should resolve major font theme attributes", () => {
+    expect(resolveThemeFontAttribute("majorHAnsi", mockTheme)).toBe("Ubuntu");
+    expect(resolveThemeFontAttribute("majorAscii", mockTheme)).toBe("Ubuntu");
+    expect(resolveThemeFontAttribute("majorEastAsia", mockTheme)).toBe("SimHei");
+    expect(resolveThemeFontAttribute("majorBidi", mockTheme)).toBe("Arial Unicode MS");
+  });
+
+  it("should return undefined for unknown theme attributes", () => {
+    expect(resolveThemeFontAttribute("unknownTheme", mockTheme)).toBeUndefined();
+    expect(resolveThemeFontAttribute("", mockTheme)).toBeUndefined();
+  });
+
+  it("should return undefined when font is not in theme", () => {
+    const emptyTheme: DocxTheme = {
+      colors: new Map(),
+      fonts: {
+        major: new Map(),
+        minor: new Map()
+      }
+    };
+    
+    expect(resolveThemeFontAttribute("minorHAnsi", emptyTheme)).toBeUndefined();
+  });
+});
+
+describe("Theme Color Resolution", () => {
+  const mockTheme: DocxTheme = {
+    colors: new Map([
+      ["dk1", "#000000"],
+      ["lt1", "#FFFFFF"],
+      ["accent1", "#4F81BD"],
+      ["accent2", "#C0504D"]
+    ]),
+    fonts: {
+      major: new Map(),
+      minor: new Map()
+    }
+  };
+
+  it("should resolve direct color references", () => {
+    expect(resolveThemeColor("dk1", mockTheme)).toBe("#000000");
+    expect(resolveThemeColor("lt1", mockTheme)).toBe("#FFFFFF");
+    expect(resolveThemeColor("accent1", mockTheme)).toBe("#4F81BD");
+  });
+
+  it("should resolve mapped color references", () => {
+    expect(resolveThemeColor("text1", mockTheme)).toBe("#000000"); // maps to dk1
+    expect(resolveThemeColor("background1", mockTheme)).toBe("#FFFFFF"); // maps to lt1
+    expect(resolveThemeColor("tx1", mockTheme)).toBe("#000000"); // maps to dk1
+    expect(resolveThemeColor("bg1", mockTheme)).toBe("#FFFFFF"); // maps to lt1
+  });
+
+  it("should return undefined for unknown colors", () => {
+    expect(resolveThemeColor("unknownColor", mockTheme)).toBeUndefined();
+    expect(resolveThemeColor("", mockTheme)).toBeUndefined();
+  });
+});
+
+describe("Theme Font Resolution (Traditional)", () => {
+  const mockTheme: DocxTheme = {
+    colors: new Map(),
+    fonts: {
+      major: new Map([
+        ["latin", "Ubuntu"],
+        ["ea", "SimHei"]
+      ]),
+      minor: new Map([
+        ["latin", "Ubuntu"],
+        ["ea", "SimSun"]
+      ])
+    }
+  };
+
+  it("should resolve major theme font references", () => {
+    expect(resolveThemeFont("+mj-lt", mockTheme)).toBe("Ubuntu");
+    expect(resolveThemeFont("+mj-ea", mockTheme)).toBe("SimHei");
+  });
+
+  it("should resolve minor theme font references", () => {
+    expect(resolveThemeFont("+mn-lt", mockTheme)).toBe("Ubuntu");
+    expect(resolveThemeFont("+mn-ea", mockTheme)).toBe("SimSun");
+  });
+
+  it("should return undefined for non-theme font references", () => {
+    expect(resolveThemeFont("Times New Roman", mockTheme)).toBeUndefined();
+    expect(resolveThemeFont("Arial", mockTheme)).toBeUndefined();
+  });
+
+  it("should return undefined for invalid theme references", () => {
+    expect(resolveThemeFont("+invalid", mockTheme)).toBeUndefined();
+    expect(resolveThemeFont("+mj", mockTheme)).toBeUndefined();
+    expect(resolveThemeFont("+unknown-script", mockTheme)).toBeUndefined();
+  });
+
+  it("should handle missing theme fonts gracefully", () => {
+    expect(resolveThemeFont("+mj-cs", mockTheme)).toBeUndefined(); // cs not in theme
+    expect(resolveThemeFont("+mn-cs", mockTheme)).toBeUndefined(); // cs not in theme
+  });
+});

--- a/packages/parser/src/parsers/docx/theme-parser.ts
+++ b/packages/parser/src/parsers/docx/theme-parser.ts
@@ -229,3 +229,30 @@ export function resolveThemeFont(fontRef: string, theme: DocxTheme): string | un
 
   return undefined;
 }
+
+/**
+ * Resolve theme font attribute reference (e.g., "minorHAnsi", "majorEastAsia")
+ * @param themeRef - Theme reference (e.g., "minorHAnsi", "majorEastAsia", "minorBidi")
+ * @param theme - Document theme
+ * @returns Resolved font name or undefined
+ */
+export function resolveThemeFontAttribute(themeRef: string, theme: DocxTheme): string | undefined {
+  // Map theme font attributes to theme font categories
+  const themeMap: Record<string, { type: "major" | "minor"; script: string }> = {
+    // Minor fonts
+    minorHAnsi: { type: "minor", script: "latin" },
+    minorAscii: { type: "minor", script: "latin" },
+    minorEastAsia: { type: "minor", script: "ea" },
+    minorBidi: { type: "minor", script: "cs" },
+    // Major fonts
+    majorHAnsi: { type: "major", script: "latin" },
+    majorAscii: { type: "major", script: "latin" },
+    majorEastAsia: { type: "major", script: "ea" },
+    majorBidi: { type: "major", script: "cs" },
+  };
+
+  const mapping = themeMap[themeRef];
+  if (!mapping) return undefined;
+
+  return theme.fonts[mapping.type].get(mapping.script);
+}

--- a/packages/parser/src/parsers/docx/types.ts
+++ b/packages/parser/src/parsers/docx/types.ts
@@ -54,6 +54,7 @@ export interface DocxRun {
   bidi?: boolean; // Bidirectional text (w:bidi attribute on w:lang)
   rtl?: boolean; // Right-to-left text direction (w:rtl)
   verticalAlign?: ST_VerticalAlignRun; // Vertical alignment (superscript/subscript/baseline)
+  border?: DocxBorder; // Text border (w:bdr)
 }
 
 export interface DocxBorder {


### PR DESCRIPTION
## Summary
- Add run-level border support for DOCX text parsing
- Implement border property in DocxRun interface and DocxRunProperties 
- Parse `w:bdr` elements in run properties using existing border utilities
- Integrate with style cascade system for proper inheritance
- Extract border tests to separate file to meet size guidelines

## Key Changes
- **Types**: Added `border?: DocxBorder` to `DocxRun` and `DocxRunProperties` interfaces
- **Parser**: Enhanced run parser to parse `w:bdr` elements using `parseBorder` function  
- **Tests**: Added comprehensive tests in dedicated `run-border.test.ts` file
- **Integration**: Border properties work with existing style cascade system

## Implementation Details
- Uses existing `border-parser.ts` utilities for consistent parsing
- Supports all border properties: style, color, size (eighth-points), space (points)
- Maintains compatibility with existing paragraph border functionality
- Proper OOXML type integration with `@browser-document-viewer/ooxml-types`

## Test Coverage
- ✅ Basic border parsing with auto color
- ✅ Colored border parsing with hex values  
- ✅ Runs without borders (undefined handling)
- ✅ Borders combined with other text formatting
- ✅ All existing tests continue to pass

## Resolves
This implementation handles the 3 text border instances found in 005.docx analysis:
- Run-level borders: `<w:bdr w:val="single" w:sz="4" w:space="0" w:color="auto"/>`
- Integrates with existing paragraph border support

🤖 Generated with [Claude Code](https://claude.ai/code)