### PR TITLE
feat: add hyperlink support to DOCX DOM parser

### DIFF
--- a/packages/core/src/formats/docx/docx-reader.ts
+++ b/packages/core/src/formats/docx/docx-reader.ts
@@ -101,8 +101,19 @@ export const readDocx = (buffer: ArrayBuffer): Effect.Effect<DocxDocument, DocxP
         numbering = yield* parseNumberingXmlWithDom(numberingContent);
       }
 
+      // Try to get relationships for hyperlinks
+      let relationshipsContent: string | undefined;
+      let relationshipsXml = unzipped["word/_rels/document.xml.rels"];
+      if (!relationshipsXml) {
+        relationshipsXml = unzipped["_rels/document.xml.rels"];
+      }
+      if (relationshipsXml) {
+        relationshipsContent = strFromU8(relationshipsXml);
+        debug.log("Relationships XML length:", relationshipsContent.length);
+      }
+
       // Parse the XML to extract text using DOM parser instead of regex
-      const paragraphs = yield* parseDocumentXmlWithDom(xmlContent);
+      const paragraphs = yield* parseDocumentXmlWithDom(xmlContent, relationshipsContent);
 
       return { paragraphs, numbering };
     } catch (error) {


### PR DESCRIPTION
## Summary

- Added hyperlink support to the DOCX DOM parser
- Modified DOM parser to accept optional relationships XML parameter  
- Implemented hyperlink parsing in document order to maintain text flow
- Added hyperlink property to DocxRun interface for URL storage
- Support both external URLs (r:id) and internal anchors (w:anchor)

## Implementation Details

- **DOM Parser Changes**: Enhanced `parseDocumentXmlWithDom` to accept relationships XML
- **Relationship Loading**: Added loading for hyperlink URL resolution from document.xml.rels
- **Document Order Parsing**: Process hyperlinks and regular runs in document order to preserve text flow
- **Helper Function**: Created `extractRunData` to avoid code duplication between hyperlink and regular runs
- **URL Resolution**: Support both external URLs via relationship IDs and internal anchors

## Test Coverage

- All 526 tests passing
- Added comprehensive hyperlink integration tests
- Verified document order preservation for mixed content
- Tested both external URLs and internal anchors

🤖 Generated with [Claude Code](https://claude.ai/code)