### PR TITLE
feat: add comprehensive image support to DOCX parser

### DIFF
--- a/packages/core/src/formats/docx/docx-to-markdown.ts
+++ b/packages/core/src/formats/docx/docx-to-markdown.ts
@@ -9,6 +9,7 @@ import {
   readDocx,
 } from "./docx-reader";
 import { fieldToMarkdown } from "./form-field-parser";
+import { formatImageAsMarkdown } from "./image-parser";
 import {
   type EnhancedDocxDocument,
   type DocxMetadata,
@@ -423,6 +424,11 @@ const formatListItemWithFormat = (
 
 // Format a single run with inline formatting
 const formatRun = (run: DocxRun): string => {
+  // Handle images first
+  if (run.image) {
+    return formatImageAsMarkdown(run.image);
+  }
+
   let text = run.text;
 
   // Convert tabs to spaces (4 spaces per tab for better markdown readability)

--- a/packages/core/test/image-integration.test.ts
+++ b/packages/core/test/image-integration.test.ts
@@ -1,0 +1,191 @@
+import { describe, test, expect } from "bun:test";
+import { Effect } from "effect";
+import { parseDocumentXmlWithDom } from "../src/formats/docx/dom-parser";
+
+describe("Image Integration Tests", () => {
+  test("should handle document XML with image drawing elements", async () => {
+    const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:p>
+      <w:r>
+        <w:t>Text before image: </w:t>
+      </w:r>
+    </w:p>
+    <w:p>
+      <w:r>
+        <w:drawing>
+          <wp:inline distT="0" distB="0" distL="0" distR="0">
+            <wp:extent cx="3245610" cy="2247253"/>
+            <wp:docPr id="1" name="Picture 1" descr="A sample image"/>
+            <a:graphic>
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                <pic:pic>
+                  <pic:blipFill>
+                    <a:blip r:embed="rId1"/>
+                  </pic:blipFill>
+                </pic:pic>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>
+    </w:p>
+    <w:p>
+      <w:r>
+        <w:t>Text after image.</w:t>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`;
+
+    const relationshipsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png" TargetMode="Internal"/>
+</Relationships>`;
+
+    const result = await Effect.runPromise(parseDocumentXmlWithDom(documentXml, relationshipsXml));
+
+    expect(result).toHaveLength(3);
+
+    // First paragraph: text only
+    expect(result[0]?.runs).toHaveLength(1);
+    expect(result[0]?.runs[0]?.text).toBe("Text before image: ");
+    expect(result[0]?.runs[0]?.image).toBeUndefined();
+
+    // Second paragraph: image
+    expect(result[1]?.runs).toHaveLength(1);
+    expect(result[1]?.runs[0]?.text).toBe("");
+    expect(result[1]?.runs[0]?.image).toEqual({
+      relationshipId: "rId1",
+      width: 3245610,
+      height: 2247253,
+      title: "Picture 1",
+      description: "A sample image",
+      filePath: "media/image1.png",
+    });
+
+    // Third paragraph: text only
+    expect(result[2]?.runs).toHaveLength(1);
+    expect(result[2]?.runs[0]?.text).toBe("Text after image.");
+    expect(result[2]?.runs[0]?.image).toBeUndefined();
+  });
+
+  test("should handle paragraph with mixed text and image content", async () => {
+    const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:p>
+      <w:r>
+        <w:t>Check this image: </w:t>
+      </w:r>
+      <w:r>
+        <w:drawing>
+          <wp:inline>
+            <wp:extent cx="1000000" cy="1000000"/>
+            <wp:docPr id="2" name="Inline Image"/>
+            <a:graphic>
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                <pic:pic>
+                  <pic:blipFill>
+                    <a:blip r:embed="rId2"/>
+                  </pic:blipFill>
+                </pic:pic>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>
+      <w:r>
+        <w:t> and more text after.</w:t>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`;
+
+    const relationshipsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/diagram.jpg"/>
+</Relationships>`;
+
+    const result = await Effect.runPromise(parseDocumentXmlWithDom(documentXml, relationshipsXml));
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.runs).toHaveLength(3);
+
+    // First run: text
+    expect(result[0]?.runs[0]?.text).toBe("Check this image: ");
+    expect(result[0]?.runs[0]?.image).toBeUndefined();
+
+    // Second run: image
+    expect(result[0]?.runs[1]?.text).toBe("");
+    expect(result[0]?.runs[1]?.image?.relationshipId).toBe("rId2");
+    expect(result[0]?.runs[1]?.image?.filePath).toBe("media/diagram.jpg");
+
+    // Third run: text
+    expect(result[0]?.runs[2]?.text).toBe(" and more text after.");
+    expect(result[0]?.runs[2]?.image).toBeUndefined();
+  });
+
+  test("should handle document without images correctly", async () => {
+    const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:r>
+        <w:t>Just plain text without any images.</w:t>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`;
+
+    const result = await Effect.runPromise(parseDocumentXmlWithDom(documentXml));
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.runs).toHaveLength(1);
+    expect(result[0]?.runs[0]?.text).toBe("Just plain text without any images.");
+    expect(result[0]?.runs[0]?.image).toBeUndefined();
+  });
+
+  test("should handle drawing elements without relationship resolution", async () => {
+    const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:p>
+      <w:r>
+        <w:drawing>
+          <wp:inline>
+            <wp:extent cx="2000000" cy="1500000"/>
+            <wp:docPr id="3" name="Unknown Image"/>
+            <a:graphic>
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                <pic:pic>
+                  <pic:blipFill>
+                    <a:blip r:embed="rId999"/>
+                  </pic:blipFill>
+                </pic:pic>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`;
+
+    // No relationships XML provided
+    const result = await Effect.runPromise(parseDocumentXmlWithDom(documentXml));
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.runs).toHaveLength(1);
+    expect(result[0]?.runs[0]?.text).toBe("");
+    expect(result[0]?.runs[0]?.image).toEqual({
+      relationshipId: "rId999",
+      width: 2000000,
+      height: 1500000,
+      title: "Unknown Image",
+      description: undefined,
+      filePath: undefined,
+    });
+  });
+});

--- a/packages/core/test/image-markdown.test.ts
+++ b/packages/core/test/image-markdown.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect } from "bun:test";
+import { convertDocxToMarkdown } from "../src/formats/docx/docx-to-markdown";
+import type { DocxDocument, DocxParagraph, DocxRun } from "../src/formats/docx/docx-reader";
+import type { DocxImage } from "../src/formats/docx/image-parser";
+
+describe("Image to Markdown Conversion", () => {
+  test("should convert document with images to markdown", () => {
+    const image: DocxImage = {
+      relationshipId: "rId1",
+      title: "Sample Image",
+      description: "A test image",
+      filePath: "media/image1.png",
+      base64Data: "iVBORw0KGgo=",
+    };
+
+    const document: DocxDocument = {
+      paragraphs: [
+        {
+          type: "paragraph",
+          runs: [
+            {
+              text: "Here is an image: ",
+              bold: false,
+              italic: false,
+            },
+            {
+              text: "",
+              image: image,
+            },
+            {
+              text: " and some text after.",
+            },
+          ],
+        },
+      ],
+    };
+
+    const markdown = convertDocxToMarkdown(document);
+
+    expect(markdown).toBe(
+      "Here is an image: ![A test image](data:image/png;base64,iVBORw0KGgo=) and some text after."
+    );
+  });
+
+  test("should handle image-only paragraphs", () => {
+    const image: DocxImage = {
+      relationshipId: "rId2",
+      title: "Standalone Image",
+      filePath: "media/diagram.jpg",
+    };
+
+    const document: DocxDocument = {
+      paragraphs: [
+        {
+          type: "paragraph",
+          runs: [
+            {
+              text: "Text before image.",
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          runs: [
+            {
+              text: "",
+              image: image,
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          runs: [
+            {
+              text: "Text after image.",
+            },
+          ],
+        },
+      ],
+    };
+
+    const markdown = convertDocxToMarkdown(document);
+
+    expect(markdown).toBe(
+      "Text before image.\n![Standalone Image](media/diagram.jpg)\nText after image."
+    );
+  });
+
+  test("should handle multiple images in same paragraph", () => {
+    const image1: DocxImage = {
+      relationshipId: "rId1",
+      title: "First Image",
+      filePath: "media/image1.png",
+    };
+
+    const image2: DocxImage = {
+      relationshipId: "rId2",
+      title: "Second Image",
+      filePath: "media/image2.jpg",
+    };
+
+    const document: DocxDocument = {
+      paragraphs: [
+        {
+          type: "paragraph",
+          runs: [
+            {
+              text: "",
+              image: image1,
+            },
+            {
+              text: " and ",
+            },
+            {
+              text: "",
+              image: image2,
+            },
+          ],
+        },
+      ],
+    };
+
+    const markdown = convertDocxToMarkdown(document);
+
+    expect(markdown).toBe(
+      "![First Image](media/image1.png) and ![Second Image](media/image2.jpg)"
+    );
+  });
+
+  test("should handle images without file paths", () => {
+    const image: DocxImage = {
+      relationshipId: "rId999",
+      title: "Missing Image",
+    };
+
+    const document: DocxDocument = {
+      paragraphs: [
+        {
+          type: "paragraph",
+          runs: [
+            {
+              text: "",
+              image: image,
+            },
+          ],
+        },
+      ],
+    };
+
+    const markdown = convertDocxToMarkdown(document);
+
+    expect(markdown).toBe("![Missing Image](placeholder-image)");
+  });
+});

--- a/packages/core/test/image-parsing.test.ts
+++ b/packages/core/test/image-parsing.test.ts
@@ -1,0 +1,231 @@
+import { describe, test, expect } from "bun:test";
+import { Effect } from "effect";
+import {
+  parseImageRelationships,
+  parseDrawingElement,
+  extractImageFromZip,
+  formatImageAsMarkdown,
+  emusToPixels,
+  type ImageRelationship,
+  type DocxImage,
+} from "../src/formats/docx/image-parser";
+
+describe("Image Parser", () => {
+  describe("parseImageRelationships", () => {
+    test("should parse image relationships from relationships XML", async () => {
+      const relationshipsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png" TargetMode="Internal"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image2.jpg"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com" TargetMode="External"/>
+</Relationships>`;
+
+      const result = await Effect.runPromise(parseImageRelationships(relationshipsXml));
+
+      expect(result.size).toBe(2);
+      expect(result.get("rId1")).toEqual({
+        id: "rId1",
+        target: "media/image1.png",
+        targetMode: "Internal",
+      });
+      expect(result.get("rId2")).toEqual({
+        id: "rId2",
+        target: "media/image2.jpg",
+      });
+      expect(result.has("rId3")).toBe(false); // Not an image relationship
+    });
+
+    test("should handle empty relationships XML", async () => {
+      const relationshipsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+</Relationships>`;
+
+      const result = await Effect.runPromise(parseImageRelationships(relationshipsXml));
+
+      expect(result.size).toBe(0);
+    });
+
+    test("should handle malformed relationships XML", async () => {
+      const relationshipsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+</Relationships>`;
+
+      const result = await Effect.runPromise(parseImageRelationships(relationshipsXml));
+
+      expect(result.size).toBe(0); // Missing Id attribute
+    });
+  });
+
+  describe("parseDrawingElement", () => {
+    test("should parse drawing element with image", async () => {
+      const drawingXml = `<w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+    <wp:extent cx="3245610" cy="2247253"/>
+    <wp:docPr id="1" name="Picture 1" descr="Test image description"/>
+    <a:graphic>
+      <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:pic>
+          <pic:blipFill>
+            <a:blip r:embed="rId1"/>
+          </pic:blipFill>
+        </pic:pic>
+      </a:graphicData>
+    </a:graphic>
+  </wp:inline>
+</w:drawing>`;
+
+      const imageRelationships = new Map<string, ImageRelationship>([
+        ["rId1", { id: "rId1", target: "media/image1.png" }],
+      ]);
+
+      const result = await Effect.runPromise(parseDrawingElement(drawingXml, imageRelationships));
+
+      expect(result).toEqual({
+        relationshipId: "rId1",
+        width: 3245610,
+        height: 2247253,
+        title: "Picture 1",
+        description: "Test image description",
+        filePath: "media/image1.png",
+      });
+    });
+
+    test("should return null for drawing without pictures", async () => {
+      const drawingXml = `<w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+    <wp:extent cx="3245610" cy="2247253"/>
+  </wp:inline>
+</w:drawing>`;
+
+      const imageRelationships = new Map<string, ImageRelationship>();
+
+      const result = await Effect.runPromise(parseDrawingElement(drawingXml, imageRelationships));
+
+      expect(result).toBeNull();
+    });
+
+    test("should handle missing relationship", async () => {
+      const drawingXml = `<w:drawing xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+    <wp:extent cx="3245610" cy="2247253"/>
+    <wp:docPr id="1" name="Picture 1"/>
+    <a:graphic>
+      <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:pic>
+          <pic:blipFill>
+            <a:blip r:embed="rId1"/>
+          </pic:blipFill>
+        </pic:pic>
+      </a:graphicData>
+    </a:graphic>
+  </wp:inline>
+</w:drawing>`;
+
+      const imageRelationships = new Map<string, ImageRelationship>();
+
+      const result = await Effect.runPromise(parseDrawingElement(drawingXml, imageRelationships));
+
+      expect(result).toEqual({
+        relationshipId: "rId1",
+        width: 3245610,
+        height: 2247253,
+        title: "Picture 1",
+        description: undefined,
+        filePath: undefined,
+      });
+    });
+  });
+
+  describe("extractImageFromZip", () => {
+    test("should extract image from ZIP at correct path", async () => {
+      const mockImageData = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]); // PNG header
+      const unzipped = {
+        "word/media/image1.png": mockImageData,
+      };
+
+      const result = await Effect.runPromise(extractImageFromZip(unzipped, "media/image1.png"));
+
+      expect(result).toBe("iVBORw0KGgo="); // Base64 of PNG header
+    });
+
+    test("should try alternative paths for image", async () => {
+      const mockImageData = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]); // PNG header
+      const unzipped = {
+        "media/image1.png": mockImageData, // Image at root level
+      };
+
+      const result = await Effect.runPromise(extractImageFromZip(unzipped, "media/image1.png"));
+
+      expect(result).toBe("iVBORw0KGgo="); // Should find it at alternative path
+    });
+
+    test("should fail when image not found", async () => {
+      const unzipped = {};
+
+      const result = Effect.runPromise(extractImageFromZip(unzipped, "media/missing.png"));
+
+      await expect(result).rejects.toThrow("Image not found: media/missing.png");
+    });
+  });
+
+  describe("emusToPixels", () => {
+    test("should convert EMUs to pixels correctly", () => {
+      expect(emusToPixels(914400)).toBe(96); // 1 inch at 96 DPI
+      expect(emusToPixels(457200)).toBe(48); // 0.5 inch at 96 DPI
+      expect(emusToPixels(0)).toBe(0);
+    });
+  });
+
+  describe("formatImageAsMarkdown", () => {
+    test("should format image with base64 data", () => {
+      const image: DocxImage = {
+        relationshipId: "rId1",
+        title: "Test Image",
+        description: "A test image",
+        filePath: "media/image1.png",
+        base64Data: "iVBORw0KGgo=",
+      };
+
+      const result = formatImageAsMarkdown(image);
+
+      expect(result).toBe("![A test image](data:image/png;base64,iVBORw0KGgo=)");
+    });
+
+    test("should format image with file path only", () => {
+      const image: DocxImage = {
+        relationshipId: "rId1",
+        title: "Test Image",
+        filePath: "media/image1.jpg",
+      };
+
+      const result = formatImageAsMarkdown(image);
+
+      expect(result).toBe("![Test Image](media/image1.jpg)");
+    });
+
+    test("should use fallback for image without data or path", () => {
+      const image: DocxImage = {
+        relationshipId: "rId1",
+        title: "Test Image",
+      };
+
+      const result = formatImageAsMarkdown(image);
+
+      expect(result).toBe("![Test Image](placeholder-image)");
+    });
+
+    test("should detect JPEG MIME type correctly", () => {
+      const image: DocxImage = {
+        relationshipId: "rId1",
+        title: "JPEG Image",
+        filePath: "media/image1.jpg",
+        base64Data: "/9j/4AAQSkZJRgABAQEA",
+      };
+
+      const result = formatImageAsMarkdown(image);
+
+      expect(result).toBe("![JPEG Image](data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEA)");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements complete image parsing infrastructure for DOCX documents
- Adds support for w:drawing elements and DrawingML namespaces
- Enables binary image extraction from ZIP archives with base64 encoding
- Integrates images into both DOM and markdown conversion pipelines

## Key Features
- Parses w:drawing elements containing images
- Resolves image relationships from document.xml.rels
- Extracts binary images from ZIP and converts to base64 for browser compatibility
- Handles EMU (English Metric Units) to pixel conversion for dimensions
- Supports both embedded images and external references
- Maintains document order with mixed text and image content

## Test Coverage
- 20+ comprehensive unit and integration tests
- Tests for relationship parsing, drawing element parsing, and markdown conversion
- Error handling for missing images and malformed XML
- Synthetic test data following project testing policy

## Technical Implementation
- Created dedicated image-parser.ts module with all image functionality
- Extended DocxRun interface with optional image property
- Modified DOM parser to handle w:drawing elements in document order
- Added formatImageAsMarkdown function for markdown conversion
- Cross-platform XMLSerializer support for browser and Node.js

🤖 Generated with [Claude Code](https://claude.ai/code)